### PR TITLE
Fix bug when passing sereval collections.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,7 @@ function plugin(options) {
     }
 
     var collectionsRegExpString = collections.join('|');
-    var collectionsRegExp = new RegExp('^' + collectionsRegExpString);
+    var collectionsRegExp = new RegExp('^(' + collectionsRegExpString + ')');
 
     if (locale) {
         moment.locale(locale);


### PR DESCRIPTION
When passing `[posts, ando]` as collections, file names are matched against the regular expression `^posts|ando`. This expression also matches the folder name `rando` (see test fixtures).

By adding parentheses to the regular expression `^(posts|ando)`, the matching behaves as expected (i.e. in line with individual collections).