### PR TITLE
Post with publishDate and date appears twice.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,13 +66,12 @@ function plugin(options) {
         var metadata = metalsmith.metadata();
         var archive = {};
         Object.keys(files).forEach(function (key) {
-            var valueFound = false;
             var file;
             var year;
             if (collectionsRegExp.test(key)) {
                 file = files[key];
-                dateFields.forEach(function (value) {
-                    if (!valueFound && file[value]) {
+                for (value of dateFields) {
+                    if (file[value]) {
                         // this will quit once the first instance is found
                         year = moment.utc(file[value]);
                         year = year.get('year');
@@ -82,11 +81,9 @@ function plugin(options) {
                         // mainly used for testing
                         file.fileName = key;
                         archive[year].push(file);
-                        valueFound = true;
-                    } else {
-                        valueFound = false;
+                        break;
                     }
-                });
+                }
             }
         });
 


### PR DESCRIPTION
If a post has `publishDate` and `date`, it is archived for both dates.

This happens because in the first iteration (`publishDate`), the post is added to the archive and `valueFound` is set to `true`. In the second iteration (`modifiedDate`), `valueFound` is set to `false` in the `else` branch. That's why in the third iteration (`date`), the post is added to the archive again for that year.

Generally, I would prefer a `for` loop or `Array.prototype.reduce()` when early exit is needed, `Array.protoype.forEach()` isn't really suitable for this.

To test this, a post should be added to the fixtures which has `publishDate` and `date` in different years, but no `modifiedDate`.